### PR TITLE
Feature: Make LocalConfiguration.php writable

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -14,9 +14,14 @@ require_once(__DIR__ . '/set.php');
 require_once(__DIR__ . '/recipe/db_init.php');
 require_once(__DIR__ . '/recipe/deploy_check_branch_local.php');
 require_once(__DIR__ . '/recipe/deploy_upload_code.php');
+require_once(__DIR__ . '/recipe/deploy_writable_local_configuration.php');
 require_once(__DIR__ . '/recipe/logs_php.php');
 require_once(__DIR__ . '/recipe/sequelace.php');
 
 // prevent pipeline fail on first deploy (no tables)
 // + enable database copy in feature branch deployment
 before('db:truncate', 'db:init');
+
+// make LocalConfiguration.php from git writable
+// don't use deploy:update_code since it could be disabled in non-git deployment
+after('deploy:shared', 'deploy:writableLocalConfiguration');

--- a/recipe/deploy_writable_local_configuration.php
+++ b/recipe/deploy_writable_local_configuration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Deployer;
+
+task('deploy:writableLocalConfiguration', function () {
+    $remotePath = get('deploy_path') . '/' . (test('[ -L {{deploy_path}}/release ]') ? 'release' : 'current');
+    run('chmod 660 ' . $remotePath . '/public/typo3conf/LocalConfiguration.php');
+});


### PR DESCRIPTION
New task `deploy:writableLocalConfiguration` (closes #7)

This task is executed after `deploy:shared` and changes the file permission of `LocalConfiguration.php` to `660` in order to make it writable by the `www-data` user. 

