### PR TITLE
feat: add tasks for all phpfpm log types

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ set('shared_dirs', [
 
 * dep log:app
 * dep log:phpfpm
-	* dep log:phpfpm_slow
-	* dep log:phpfpm_access
-	* dep log:phpfpm_error
+	* dep log:phpfpm-slow
+	* dep log:phpfpm-access
+	* dep log:phpfpm-error
 * dep sequelace
 
 ## Non-git deployment

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ set('shared_dirs', [
 ## New useful commands
 
 * dep log:app
-* dep log:php
+* dep log:phpfpm
+	* dep log:phpfpm_slow
+	* dep log:phpfpm_access
+	* dep log:phpfpm_error
 * dep sequelace
 
 ## Non-git deployment

--- a/recipe/logs_php.php
+++ b/recipe/logs_php.php
@@ -6,14 +6,14 @@ task('logs:phpfpm', function () {
     run('tail -F /var/log/php*www*.log');
 })->verbose();
 
-task('logs:phpfpm_access', function () {
+task('logs:phpfpm-access', function () {
     run('tail -F /var/log/php*www.access.log');
 })->verbose();
 
-task('logs:phpfpm_slow', function () {
+task('logs:phpfpm-slow', function () {
     run('tail -F -n 30 /var/log/php*www.slow.log');
 })->verbose();
 
-task('logs:phpfpm_error', function () {
+task('logs:phpfpm-error', function () {
     run('tail -F -n +1 /var/log/php*www.error.log');
 })->verbose();

--- a/recipe/logs_php.php
+++ b/recipe/logs_php.php
@@ -2,6 +2,18 @@
 
 namespace Deployer;
 
-task('logs:php-fpm', function () {
-    run('tail -F /var/log/php*.log');
+task('logs:phpfpm', function () {
+    run('tail -F /var/log/php*www*.log');
+})->verbose();
+
+task('logs:phpfpm_access', function () {
+    run('tail -F /var/log/php*www.access.log');
+})->verbose();
+
+task('logs:phpfpm_slow', function () {
+    run('tail -F -n 30 /var/log/php*www.slow.log');
+})->verbose();
+
+task('logs:phpfpm_error', function () {
+    run('tail -F -n +1 /var/log/php*www.error.log');
 })->verbose();


### PR DESCRIPTION
Task has been renamed and additional tasks were added for tailing different PHP FPM log types.

- The last 30 lines are shown for slow logs in oder to display the last full stack trace.
- Generally there aren't too many errors so all can be shown.

Rotated logs are ignored, as these tasks are made to follow log output in real time.
