### PR TITLE
feat: make settings.php writeable

### DIFF
--- a/recipe/deploy_writable_local_configuration.php
+++ b/recipe/deploy_writable_local_configuration.php
@@ -4,8 +4,13 @@ namespace Deployer;
 
 task('deploy:writableLocalConfiguration', function () {
     $remotePath = get('deploy_path') . '/' . (test('[ -L {{deploy_path}}/release ]') ? 'release' : 'current');
-    $confPath = $remotePath . '/public/typo3conf/LocalConfiguration.php';
-    if (test('[ -f ' . $confPath . ' ]')) {
-        run('chmod 660 ' . $confPath);
+    $configFiles = [
+        $remotePath . '/public/typo3conf/LocalConfiguration.php',
+        $remotePath . '/config/system/settings.php',
+    ];
+    foreach ($configFiles as $filePath) {
+        if (test('[ -f ' . $filePath . ' ]')) {
+            run('chmod 660 ' . $filePath);
+        }
     }
 });


### PR DESCRIPTION
Since we disabled `writable_chmod_recursive`, the permissions of the `LocalConfiguration.php` are adjusted during deployment. In v12 the file is now moved outside of the public directory + renamed to `settings.php`. This PR tests for both files and applies 660.