### PR TITLE
feat: use media_custom to override default rsync flags for media:* commands

### DIFF
--- a/set.php
+++ b/set.php
@@ -52,7 +52,10 @@ set('log_files', 'var/log/*.log');
 set('fetch_method', 'curl');
 
 // keep permissions from source system
-set('media_rsync_flags', '-rz --perms');
+set('media_custom', [
+    'flags' => 'rzp',
+    ],
+);
 
 // disable composer version check
 set('composer_channel_autoupdate', false);


### PR DESCRIPTION
Officially supported in deployer-extended-media since 12.0.0: https://github.com/sourcebroker/deployer-extended-media/blob/master/CHANGELOG.rst