### PR TITLE
feat: add .env.local to shared_files

### DIFF
--- a/set.php
+++ b/set.php
@@ -45,6 +45,12 @@ set('shared_dirs', function () {
     ];
 });
 
+// add additional shared files
+set('shared_files', [
+    ...get('shared_files'),
+    '.env.local',
+]);
+
 // set log files dir
 set('log_files', 'var/log/*.log');
 


### PR DESCRIPTION
The `dotenv-connector` is capable to respect multiple `.env` files. Using a dedicated `.env.local` file for remote instances, it is requires to add it to the `shared_files` as well.

```diff
"helhum/dotenv-connector": {
      "env-file": ".env",
-     "adapter": "Helhum\\DotEnvConnector\\Adapter\\SymfonyDotEnv"
+     "adapter": "Helhum\\DotEnvConnector\\Adapter\\SymfonyLoadEnv"
}
```