### PR TITLE
feat: use v22.0.0 of deployer-extended-typo3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "sourcebroker/deployer-extended-typo3": "21.0.0",
+    "sourcebroker/deployer-extended-typo3": "22.0.0",
     "spooner/deployer-information": "1.4.0"
   },
   "autoload": {

--- a/set.php
+++ b/set.php
@@ -11,7 +11,9 @@ set('writable_chmod_recursive', false);
 set('writable_chmod_mode', '2770');
 
 // local host is always needed
-host('local')->set('deploy_path', getcwd());
+localhost('local')
+    ->set('bin/php', 'php')
+    ->set('deploy_path', getcwd());
 
 // read typo3 database connection from bin/typo3cms > AdditionalConfiguration.php > .env
 set('driver_typo3cms', true);


### PR DESCRIPTION
Using the newest DDEV version requires v22.0.0 of deployer-extended-database [due to changes](https://github.com/sourcebroker/deployer-extended-database/issues/33) to `.my.cnf`. This PR bumps the version + makes the required change to the local host definition.