### PR TITLE
fix: use new OptionUtility for parsing cli options

### DIFF
--- a/recipe/db_init.php
+++ b/recipe/db_init.php
@@ -2,13 +2,14 @@
 
 namespace Deployer;
 
-use SourceBroker\DeployerExtendedDatabase\Utility\ConsoleUtility;
+use SourceBroker\DeployerExtendedDatabase\Utility\OptionUtility;
 
 /**
  * Check for missing database: Run database updateschema + import database of base branch
  */
 task('db:init', function () {
-    $baseBranch = (new ConsoleUtility())->getOption('base_branch') ?: '';
+    $optionUtility = new OptionUtility(input()->getOption('options'));
+    $baseBranch = $optionUtility->getOption('base_branch');
 
     // abort if feature branch has already been configured
     if (!$baseBranch || !get('argument_host')) {

--- a/recipe/reset_from_gitlab_artifact.php
+++ b/recipe/reset_from_gitlab_artifact.php
@@ -4,14 +4,16 @@ namespace Deployer;
 
 use Deployer\Exception\GracefulShutdownException;
 use SourceBroker\DeployerExtendedDatabase\Utility\ConsoleUtility;
+use SourceBroker\DeployerExtendedDatabase\Utility\OptionUtility;
 
 task('reset:from_gitlab_artifact', function () {
     // set in deploy.php as https://gitlab.example.org/api/v4/projects/<project-id>/jobs/artifacts/<branch>/download?job=<job-of-artifact>
     $url = get('reset_gitlab_artifact_url');
     // Gitlab API token for the repository where the artifact is stored. Can be a project token.
-    $gitlabApiToken = (new ConsoleUtility())->getOption('token', true);
+    $optionUtility = new OptionUtility(input()->getOption('options'));
+    $gitlabApiToken = $optionUtility->getOption('token', true);
     // Database dumpcode that was used during the creation of the Gitlab artifact.
-    $dumpCode = (new ConsoleUtility())->getOption('dumpcode', true);
+    $dumpCode = $optionUtility->getOption('dumpcode', true);
 
     if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match('#jobs\/artifacts\/.+\/download$#', parse_url($url, PHP_URL_PATH))) {
         throw new GracefulShutdownException('Gitlab API URL is invalid: "' . $url . '"');


### PR DESCRIPTION
In version 18.0.0 of sourcebroker/deployer-extended-database, [cli parsing moved](https://github.com/sourcebroker/deployer-extended-database/blob/9a23aead89372c510cedbe6aed524816f9f035bc/CHANGELOG.rst?plain=1#L39) from `ConsoleUtility` to a new `OptionsUtility`. Since two tasks of this repo depend on this utility, deployments fail.