### PR TITLE
feat: patch media:push task due to broken rsync flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,15 @@ import-job:
     - vendor/bin/dep reset:from_gitlab_artifact --options="token:$CI_VARIABLE_WITH_API_TOKEN,dumpcode:myArtifact" host-a
   when: manual
 ```
+
+## Patch for media:push task
+
+The flag `--keep-dirlinks (-K)` is broken in recent rsync versions - this causes media:push from https://github.com/sourcebroker/deployer-extended-media to fail when syncing into symlinked directories: https://github.com/sourcebroker/deployer-extended-media/issues/9
+
+To patch this, the absolute path to the shared dir is used:
+```php
+# 37 $src = get('deploy_path') . '/' . (test('[ -L {{deploy_path}}/release ]') ? 'release' : 'current');
+$src = get('deploy_path') . '/' . 'shared';
+```
+
+Warning: All synchronised directories in **media_custom** must be **shared_dirs**.

--- a/autoload.php
+++ b/autoload.php
@@ -21,6 +21,8 @@ require_once(__DIR__ . '/recipe/logs_php.php');
 require_once(__DIR__ . '/recipe/check_requirements.php');
 require_once(__DIR__ . '/recipe/sequelace.php');
 require_once(__DIR__ . '/recipe/reset_from_gitlab_artifact.php');
+require_once(__DIR__ . '/recipe/media_push.php');
+
 
 // prevent pipeline fail on first deploy (no tables)
 // + enable database copy in feature branch deployment

--- a/recipe/media_push.php
+++ b/recipe/media_push.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Deployer;
+
+use Deployer\Exception\GracefulShutdownException;
+use SourceBroker\DeployerExtendedMedia\Utility\FileUtility;
+use SourceBroker\DeployerInstance\Configuration;
+
+/*
+ * @see https://github.com/sourcebroker/deployer-extended-media#media-push
+ */
+task('media:push', function () {
+    $targetName = get('argument_host');
+    if ($targetName === get('instance_live_name', 'live')) {
+        if (!get('media_allow_push_live', true)) {
+            throw new GracefulShutdownException(
+                'FORBIDDEN: For security its forbidden to push media to top instance: "' . $targetName . '"!'
+            );
+        }
+        if (!get('media_allow_push_live_force', false)) {
+            writeln("<error>\n\n");
+            writeln(sprintf(
+                "You going to push media from instance: \"%s\" to top instance: \"%s\". ",
+                get('local_host'),
+                $targetName
+            ));
+            writeln("This can be destructive.\n\n");
+            writeln("</error>");
+            if (!askConfirmation('Do you really want to continue?', false)) {
+                throw new GracefulShutdownException('Process aborted.');
+            }
+            if (!askConfirmation('Are you sure?', false)) {
+                throw new GracefulShutdownException('Process aborted.');
+            }
+        }
+    }
+    $src = get('deploy_path') . '/' . 'shared';
+    if (!trim($src)) {
+        throw new GracefulShutdownException('You need to specify a source path.');
+    }
+    $src = (new FileUtility)->normalizeFolder($src);
+
+    $dst = get('media_rsync_dest');
+    while (is_callable($dst)) {
+        $dst = $dst();
+    }
+    if (!trim($dst)) {
+        throw new GracefulShutdownException('You need to specify a destination path.');
+    }
+    $dst = (new FileUtility)->normalizeFolder($dst);
+
+    $targetServer = Configuration::getHost($targetName);
+    $host = $targetServer->getHostname();
+    $user = !$targetServer->getRemoteUser() ? '' : $targetServer->getRemoteUser() . '@';
+
+    $rsyncSshOptions = '';
+    $connectionOptions = $targetServer->connectionOptionsString();
+    if ($connectionOptions !== '') {
+        $rsyncSshOptions = '-e "ssh ' . $connectionOptions . ' "';
+    }
+    runLocally(
+        'rsync ' . $rsyncSshOptions . ' {{media_rsync_flags}}{{media_rsync_options}}{{media_rsync_includes}}{{media_rsync_excludes}}{{media_rsync_filter}}'
+        . ' '
+        . escapeshellarg($dst)
+        . ' '
+        . escapeshellarg($user . $host . ':' . $src)
+    );
+})->desc('Synchronize media from local instance to remote instance');


### PR DESCRIPTION
Workaround for broken rsync flag, locally tested via composer req for this branch:

```json
{
    "repositories": [
        {
          "url": "https://github.com/xima-media/xima-deployer-extended-typo3.git",
          "type": "git"
        }
    ],
    "require-dev": {
        "xima/xima-deployer-extended-typo3": "dev-media_push_rsync_fix"
    }
}
```
`ddev composer req --dev xima/xima-deployer-extended-typo3:dev-media_push_rsync_fix`

Please review, merge and publish a new release.

Thanks :)