### PR TITLE
feat: suppress verbose rsync output

### DIFF
--- a/recipe/deploy_upload_code.php
+++ b/recipe/deploy_upload_code.php
@@ -6,7 +6,7 @@ task('deploy:upload_code', function () {
     // upload files/folders
     foreach (get('upload_paths') as $path) {
         if (testLocally('[ -f ' . $path . ' ]') || testLocally('[ -d ' . $path . ' ]')) {
-            upload($path, '{{release_path}}/', ['options' => ['-R']]);
+            upload($path, '{{release_path}}/', ['options' => ['-Rq']]);
         }
     }
 


### PR DESCRIPTION
Prevents issues with the CI job log being exceeded